### PR TITLE
Update LiveEnhancementSuite.ahk

### DIFF
--- a/LiveEnhancementSuite.ahk
+++ b/LiveEnhancementSuite.ahk
@@ -1178,8 +1178,10 @@ tempautoadd := autoadd
 
 
 If (tempautoadd = 1){
-sleep, 112
-Send,{down}{enter}
+sleep, 100
+Send,{enter}				
+sleep, 100				; Updated for Live 12 compatibility. Enter is pressed, then a 100ms wait, then Enter is pressed again. Now plugins load the first time.
+Send,{enter}
 }
 Else{
 goto, skipautoadd

--- a/LiveEnhancementSuite.ahk
+++ b/LiveEnhancementSuite.ahk
@@ -1178,9 +1178,9 @@ tempautoadd := autoadd
 
 
 If (tempautoadd = 1){
-sleep, 100
+sleep, 200
 Send,{enter}				
-sleep, 100				; Updated for Live 12 compatibility. Enter is pressed, then a 100ms wait, then Enter is pressed again. Now plugins load the first time.
+sleep, 200				; Updated for Live 12 compatibility. Enter is pressed, then a 100ms wait, then Enter is pressed again. Now plugins load the first time.
 Send,{enter}
 }
 Else{


### PR DESCRIPTION
Double right-click menu now loads plugins in Live 12.

Previously plugin would load roughly on the second attempt at trying.

The new search in Ableton Live 12 works as follows:
- type plugin name
- press enter to take you to top result
- press enter again to load plugin

The old code didn't work as there was only one Send,{enter} command. I added another Send,{enter} with a sleep, 100 line before it to give it enough time to highlight the search result before sending enter command.

Seems to work okay.
All the other features of Live Enhancement Suite and there compatibility with Live 12 I have not tested.

I just wanted the menu feature of LES to work... for now.

A huge thank you to Inverted Silence for creating this AHK project. This suite has saved those precious seconds, even minutes of searching and loading plugins, that get in the way of the creative flow, for years now. Definitely an enhancement.

Inverted Silence proclaimed he was no longer developing LES for Live 12 and so I believe (this is my first ever fork) that a new branch should be created.